### PR TITLE
fix: prevent a flash of light mode before dark mode is applied

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@chakra-ui/react'
+import { Box, ColorModeScript } from '@chakra-ui/react'
 import { GoogleAnalytics } from '@next/third-parties/google'
 import type { Metadata } from 'next'
 import { Footer } from '@/components/Footer'
@@ -14,6 +14,10 @@ import {
   SITE_TITLE,
   TWITTER_HANDLE,
 } from '@/constants'
+// Imported from the module itself rather than through '@/theme', whose index
+// calls extendTheme() at module scope — a client-only call that a Server
+// Component cannot make.
+import { config } from '@/theme/config'
 import { Providers } from './providers'
 
 export const metadata: Metadata = {
@@ -59,6 +63,13 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body>
+        {/*
+          Applies the stored or system colour mode before the first paint.
+          Without it the prerendered HTML is painted in light mode and Chakra
+          only switches to dark once React has hydrated, which the 200ms
+          background transition in the theme turns into a visible flash.
+        */}
+        <ColorModeScript initialColorMode={config.initialColorMode} />
         <Providers>
           <Header />
           <Box as="main" pt={{ base: 20, md: 20 }}>


### PR DESCRIPTION
Loading the site with dark mode active showed a brief flash of the light theme.

## Cause

The prerendered HTML carries no colour-mode class on `<body>`, so the browser
paints it in light mode. Chakra's `ColorModeProvider` only reads the stored
preference (or `prefers-color-scheme`) once React has hydrated, and applies the
class from an effect.

The theme sets `transition: background 200ms linear !important` on `<body>`
(`src/theme/index.ts`), so that correction is *animated* — which is what turns
an otherwise instant swap into a visible flash.

`ColorModeScript` is Chakra's answer to exactly this: an inline, synchronous
script that resolves the mode and sets the class on `<body>`, plus
`documentElement`'s `colorScheme` and `data-theme`, before anything is painted.
It had never been added to this project — `git log -S ColorModeScript` finds
nothing — so this is a long-standing issue rather than a regression from the
Next.js 16 upgrade.

## Note on the import path

`config` is imported from `@/theme/config`, not from `@/theme`. The index calls
`extendTheme()` at module scope, which is client-only, so importing through it
fails the build with:

```
Attempted to call extendTheme() from the server but extendTheme is on the client.
```

`config.ts` contains nothing but a type import, so it is safe to read from a
Server Component. This is the same shape of problem as the component barrel
removed during the Next.js 16 upgrade: an index that pulls in more than the
importer actually needs.

No CSP change is required — `script-src` already allows `'unsafe-inline'`.

## Verification

Against a production build:

- The script lands 56 characters into `<body>`, ahead of every visible element.
  Only Next's hidden style-flush container precedes it, and that is `hidden`
  with zero height.
- On load `<body>` already carries `chakra-ui-dark`, with `data-theme="dark"`
  and `colorScheme: dark` on the root element.
- Toggling between modes still works (dark → light confirmed), and the choice
  survives a reload.
- `build` (37 static pages), `type-check`, `lint` and 101 tests all pass, with
  an empty browser console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
